### PR TITLE
[Feat] Player Move Input, Jump, GameManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ crashlytics-build.properties
 /Assets/StreamingAssets/google-services-desktop.json.meta
 /Assets/Plugins
 /Assets/Plugins.meta
+/Assets/GeneratedLocalRepo
+/Assets/GeneratedLocalRepo.meta

--- a/Assets/05.KGW_Folder/Prefabs/GameManager.prefab
+++ b/Assets/05.KGW_Folder/Prefabs/GameManager.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5568560184835631956
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7877854262590137139}
+  - component: {fileID: 7472974193570990470}
+  m_Layer: 0
+  m_Name: GameManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7877854262590137139
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5568560184835631956}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.1133132, y: 0.8984523, z: -0.028835911}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7472974193570990470
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5568560184835631956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ba0436e62a667034885411dbe4bc7ebb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05.KGW_Folder/Prefabs/GameManager.prefab.meta
+++ b/Assets/05.KGW_Folder/Prefabs/GameManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 81c6ab81374ca0b45bab1137e714ebf6
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05.KGW_Folder/Scenes/TestScene.unity
+++ b/Assets/05.KGW_Folder/Scenes/TestScene.unity
@@ -122,6 +122,63 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &201157817
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 5568560184835631956, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_Name
+      value: GameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.1133132
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.8984523
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.028835911
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7877854262590137139, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 81c6ab81374ca0b45bab1137e714ebf6, type: 3}
 --- !u!1 &268926305
 GameObject:
   m_ObjectHideFlags: 0
@@ -132,7 +189,8 @@ GameObject:
   m_Component:
   - component: {fileID: 268926306}
   - component: {fileID: 268926307}
-  m_Layer: 0
+  - component: {fileID: 268926308}
+  m_Layer: 7
   m_Name: Square
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -148,8 +206,8 @@ Transform:
   m_GameObject: {fileID: 268926305}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -5.17, y: -6.13, z: 0.10223692}
-  m_LocalScale: {x: 5, y: 11, z: 1}
+  m_LocalPosition: {x: -3.68, y: -6.13, z: 0.10223692}
+  m_LocalScale: {x: 10, y: 11, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1950237861}
@@ -206,6 +264,51 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &268926308
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 268926305}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &370806945
 GameObject:
   m_ObjectHideFlags: 0
@@ -215,7 +318,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 370806947}
-  - component: {fileID: 370806946}
+  - component: {fileID: 370806949}
+  - component: {fileID: 370806948}
+  - component: {fileID: 370806951}
+  - component: {fileID: 370806950}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -223,58 +329,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!212 &370806946
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 370806945}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!4 &370806947
 Transform:
   m_ObjectHideFlags: 0
@@ -287,9 +341,103 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 2100927702}
+  - {fileID: 1977737902}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &370806948
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 370806945}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!58 &370806949
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 370806945}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!114 &370806950
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 370806945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6134aa7d11c8eda4c81d860a354d73ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _jumpPower: 2
+  _maxJumpPower: 10
+  _maxTouchTime: 1
+  _jumpXDir: 0.3
+  _jumpYDir: 1
+--- !u!114 &370806951
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 370806945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 70d7666f455a67249b681b5d4046d99c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _playerstate: {fileID: 370806950}
 --- !u!1 &720841987
 GameObject:
   m_ObjectHideFlags: 0
@@ -300,7 +448,8 @@ GameObject:
   m_Component:
   - component: {fileID: 720841988}
   - component: {fileID: 720841989}
-  m_Layer: 0
+  - component: {fileID: 720841990}
+  m_Layer: 7
   m_Name: Square (2)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -316,7 +465,7 @@ Transform:
   m_GameObject: {fileID: 720841987}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 10.06, y: -6.13, z: 0.10223692}
+  m_LocalPosition: {x: 13.460001, y: -6.13, z: 0.10223692}
   m_LocalScale: {x: 5, y: 11, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -374,6 +523,248 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &720841990
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 720841987}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!1 &1593445864
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1593445866}
+  - component: {fileID: 1593445865}
+  m_Layer: 9
+  m_Name: Water
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1593445865
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1593445864}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!4 &1593445866
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1593445864}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 19.28, y: -9.87, z: 0}
+  m_LocalScale: {x: 70, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1606606145
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1606606148}
+  - component: {fileID: 1606606147}
+  - component: {fileID: 1606606146}
+  m_Layer: 8
+  m_Name: Egg
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!58 &1606606146
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1606606145}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!212 &1606606147
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1606606145}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1606606148
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1606606145}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 13.526157, y: 1.1318406, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1950237860
 GameObject:
   m_ObjectHideFlags: 0
@@ -383,7 +774,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1950237861}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Map
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -493,12 +884,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1977737899}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 370806947}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2072868884
 GameObject:
@@ -510,7 +901,8 @@ GameObject:
   m_Component:
   - component: {fileID: 2072868885}
   - component: {fileID: 2072868886}
-  m_Layer: 0
+  - component: {fileID: 2072868887}
+  m_Layer: 7
   m_Name: Square (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -526,7 +918,7 @@ Transform:
   m_GameObject: {fileID: 2072868884}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.42, y: -6.13, z: 0.10223692}
+  m_LocalPosition: {x: 5.82, y: -6.13, z: 0.10223692}
   m_LocalScale: {x: 5, y: 11, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -584,10 +976,163 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!61 &2072868887
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2072868884}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!1 &2100927701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2100927702}
+  - component: {fileID: 2100927704}
+  - component: {fileID: 2100927703}
+  m_Layer: 0
+  m_Name: Skin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2100927702
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100927701}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 370806947}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &2100927703
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100927701}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!212 &2100927704
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2100927701}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 1977737902}
   - {fileID: 370806947}
   - {fileID: 1950237861}
+  - {fileID: 201157817}
+  - {fileID: 1606606148}
+  - {fileID: 1593445866}

--- a/Assets/05.KGW_Folder/Scripts/InGameUI.meta
+++ b/Assets/05.KGW_Folder/Scripts/InGameUI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b0f2fb1ff4dade49a65a4d38f2f1818
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05.KGW_Folder/Scripts/InGameUI/InGameUIManager.cs
+++ b/Assets/05.KGW_Folder/Scripts/InGameUI/InGameUIManager.cs
@@ -1,0 +1,45 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+public class InGameUIManager : MonoBehaviour
+{
+    [Header("Play Time UI Reference")]
+    [SerializeField] TMP_Text _playTimeText;
+
+    [Header("Egg Count UI Reference")]
+    [SerializeField] TMP_Text _eggCountText;
+
+    // 달걀 획득 UI 이벤트 구독
+    private void Start()
+    {
+        GameManager.Instance.OnEggCountChange += UpdateGetEggUI;
+        // 시작할 시 획득한 달걀은 0이므로 UI설정
+        UpdateGetEggUI(0);
+    }
+
+    private void Update()
+    {
+        // 플레이 타임 저장
+        float playTime = GameManager.Instance._playTime;
+
+        // 시간(분) 설정
+        int minuteTime = (int)playTime / 60;
+        int secondTime = (int)playTime % 60;
+
+        _playTimeText.text = $"{minuteTime} : {secondTime}";
+    }
+
+    // 달걀 획득 UI 이벤트 해제
+    private void OnDestroy()
+    {
+        GameManager.Instance.OnEggCountChange -= UpdateGetEggUI;
+    }
+
+    // 달걀 획득 UI
+    private void UpdateGetEggUI(int totalEgg)
+    {
+        _eggCountText.text = $"x {totalEgg}";
+    }
+}

--- a/Assets/05.KGW_Folder/Scripts/InGameUI/InGameUIManager.cs.meta
+++ b/Assets/05.KGW_Folder/Scripts/InGameUI/InGameUIManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db7c74e119a7c5c4f8b00030b445a271
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05.KGW_Folder/Scripts/Manager.meta
+++ b/Assets/05.KGW_Folder/Scripts/Manager.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 90337c79bd65b3749a2c158fa806aec5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05.KGW_Folder/Scripts/Manager/GameManager.cs
+++ b/Assets/05.KGW_Folder/Scripts/Manager/GameManager.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+public class GameManager : MonoBehaviour
+{
+    static GameManager instance;
+    int _totalEggCount = 0;
+    bool _isGoal = false;
+    public Vector3 _startPos;
+    public float _playTime = 0f;
+
+    // 달걀 획득에 대한 이벤트 (UI 적용)
+    // TODO: Egg UI에서 Start와 OnDestroy에 이벤트 구독과 취소 설정 필요
+    public event Action<int> OnEggCountChange;
+
+    public static GameManager Instance
+    {
+        get
+        {
+            if(instance == null)    // 게임매니저가 하이어라키창에 없으면 게임매니저 생성
+            {
+                GameObject gameObject = new GameObject("GameManager");
+                instance = gameObject.AddComponent<GameManager>();
+            }
+            return instance;
+        }
+    }
+
+    private void Awake()
+    {
+        // 게임매니저 생성
+        CreateGameManager();
+    }
+
+    private void Update()
+    {
+        // 결승점 도착 까지 플레이 시간 측정
+        if(!_isGoal)
+        {
+            _playTime += Time.deltaTime;
+        }
+    }
+
+    // 게임매니저가 생성한게 있으면 생성하지 않고 중복으로 생성 시 삭제
+    public void CreateGameManager()
+    {
+        if (instance == null)
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    // 시작위치 저장
+    public void StartPosSave(Transform pos)
+    {
+        _startPos = pos.position;
+    }
+
+    // 결승점 도착
+    public void StopPlayTime()
+    {
+        _isGoal = true;
+    }
+
+    // 달걀 획득
+    public void GetEgg(int eggCount)
+    {
+        _totalEggCount += eggCount;
+        OnEggCountChange?.Invoke(_totalEggCount);   // 이벤트 호출
+        Debug.Log($"달걀을 {eggCount}개 획득을 했습니다. 총 획득 달걀 : {_totalEggCount}");
+    }
+
+}

--- a/Assets/05.KGW_Folder/Scripts/Manager/GameManager.cs.meta
+++ b/Assets/05.KGW_Folder/Scripts/Manager/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ba0436e62a667034885411dbe4bc7ebb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05.KGW_Folder/Scripts/Manager/InGameNetworkManager.cs
+++ b/Assets/05.KGW_Folder/Scripts/Manager/InGameNetworkManager.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class InGameNetworkManager : MonoBehaviour
+{
+    
+}

--- a/Assets/05.KGW_Folder/Scripts/Manager/InGameNetworkManager.cs.meta
+++ b/Assets/05.KGW_Folder/Scripts/Manager/InGameNetworkManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d12c0591c13d41a439a59389eb98af79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05.KGW_Folder/Scripts/Player.meta
+++ b/Assets/05.KGW_Folder/Scripts/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 905bb2b71fa21e940b700c7715fdc524
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05.KGW_Folder/Scripts/Player/PlayerController.cs
+++ b/Assets/05.KGW_Folder/Scripts/Player/PlayerController.cs
@@ -1,0 +1,108 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerController : MonoBehaviour
+{
+    [Header("Player State Reference")]
+    [SerializeField] PlayerState _playerstate;
+
+    Rigidbody2D _playerRigid;
+    Vector2 _jumpDir;
+    float _touchStartTime;
+    float _touchEndTime;
+    bool _isGround;
+    bool _isTouch;
+
+    private void Awake()
+    {
+        _playerRigid = GetComponent<Rigidbody2D>();
+    }
+
+    private void Start()
+    {
+        // 플레이어 시작위치 저장
+        GameManager.Instance.StartPosSave(transform);
+    }
+
+    private void Update()
+    {
+        TouchInput();
+        PlayerJump();
+    }
+
+    // 화면 터치 입력
+    private void TouchInput()
+    {
+        if (!_isGround) return;
+
+        // 화면 터치 시 터치 타임 측정
+        if (Input.GetMouseButtonDown(0))
+        {
+            _touchStartTime = Time.time;
+            _isTouch = true;
+        }
+    }
+
+    // 플레이어 점프
+    private void PlayerJump()
+    {
+        if (!_isGround) return;
+        // 화면 터치 끝
+        if (Input.GetMouseButtonUp(0) && _isGround && _isTouch)
+        {
+            _touchEndTime = Time.time - _touchStartTime;
+
+            // 0 -> 1의 값으로 부드럽게 점프 동작을 보정
+            float maxTime = Mathf.Clamp01(_touchEndTime / _playerstate.MaxTouchTime);
+            float jumpPower = Mathf.Lerp(_playerstate.JumpPower, _playerstate.MaxJumpPower, maxTime);
+
+            // 앞으로의 점프 방향
+            _jumpDir = new Vector2(_playerstate.JumpXDir, _playerstate.JumpYDir).normalized;
+            _playerRigid.velocity = Vector2.zero;
+            _playerRigid.AddForce(_jumpDir * jumpPower, ForceMode2D.Impulse);
+
+            _isGround = false;
+            _isTouch = false;
+        }
+    }
+
+    // 물리적 충돌
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        if(collision.gameObject.layer == LayerMask.NameToLayer("Ground"))
+        {
+            _isGround = true;
+            _playerRigid.velocity = Vector2.zero;
+        }
+    }
+
+    // 트리거 충돌
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        // 달걀 획득
+        if(collision.gameObject.layer == LayerMask.NameToLayer("Egg"))
+        {
+            // 게임매니저의 알 개수 증가
+            GameManager.Instance.GetEgg(1);
+            Destroy(collision.gameObject);
+        }
+
+        // 물에 입수
+        if(collision.gameObject.layer == LayerMask.NameToLayer("Water"))
+        {
+            Debug.Log("물에 접촉");
+            // 게임의 처음 위치로 이동
+            _playerRigid.velocity = Vector2.zero;
+            gameObject.transform.position = GameManager.Instance._startPos;
+        }
+
+        // 결승점 도착
+        if(collision.gameObject.layer == LayerMask.NameToLayer("Goal"))
+        {
+            // 플레이 시간 정지
+            GameManager.Instance.StopPlayTime();
+        }
+
+    }
+}

--- a/Assets/05.KGW_Folder/Scripts/Player/PlayerController.cs.meta
+++ b/Assets/05.KGW_Folder/Scripts/Player/PlayerController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70d7666f455a67249b681b5d4046d99c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05.KGW_Folder/Scripts/Player/PlayerState.cs
+++ b/Assets/05.KGW_Folder/Scripts/Player/PlayerState.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerState : MonoBehaviour
+{
+    [Header("Player State")]
+
+    // Player Jump Power
+    [SerializeField] float _jumpPower = 3f;
+    public float JumpPower { get { return _jumpPower; } set { _jumpPower = value; } }
+
+    // Player Max jump Power
+    [SerializeField] float _maxJumpPower = 10f;
+    public float MaxJumpPower { get { return _maxJumpPower; } set { _maxJumpPower = value; } }
+
+    // Touch Max Jump Time
+    [SerializeField] float _maxTouchTime = 2f;
+    public float MaxTouchTime {  get { return _maxTouchTime; } set { _maxTouchTime = value; }}
+
+    // Player Jump X Direction
+    [SerializeField] float _jumpXDir = 0.2f;
+    public float JumpXDir { get { return _jumpXDir; } set { _jumpXDir = value; }}
+
+    // Player Jump Y Direction
+    [SerializeField] float _jumpYDir = 1f;
+    public float JumpYDir { get { return _jumpYDir; } set { _jumpYDir = value; } }
+
+}

--- a/Assets/05.KGW_Folder/Scripts/Player/PlayerState.cs.meta
+++ b/Assets/05.KGW_Folder/Scripts/Player/PlayerState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6134aa7d11c8eda4c81d860a354d73ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/AndroidResolverDependencies.xml
+++ b/ProjectSettings/AndroidResolverDependencies.xml
@@ -1,0 +1,37 @@
+<dependencies>
+  <packages>
+    <package>com.google.android.gms:play-services-base:18.6.0</package>
+    <package>com.google.firebase:firebase-analytics:22.4.0</package>
+    <package>com.google.firebase:firebase-app-unity:12.10.1</package>
+    <package>com.google.firebase:firebase-auth:23.2.0</package>
+    <package>com.google.firebase:firebase-auth-unity:12.10.1</package>
+    <package>com.google.firebase:firebase-common:21.0.0</package>
+    <package>com.google.firebase:firebase-database:21.0.0</package>
+    <package>com.google.firebase:firebase-database-unity:12.10.1</package>
+  </packages>
+  <files>
+    <file>Assets/GeneratedLocalRepo/Firebase/m2repository/com/google/firebase/firebase-app-unity/12.10.1/firebase-app-unity-12.10.1.aar</file>
+    <file>Assets/GeneratedLocalRepo/Firebase/m2repository/com/google/firebase/firebase-app-unity/12.10.1/firebase-app-unity-12.10.1.pom</file>
+    <file>Assets/GeneratedLocalRepo/Firebase/m2repository/com/google/firebase/firebase-auth-unity/12.10.1/firebase-auth-unity-12.10.1.aar</file>
+    <file>Assets/GeneratedLocalRepo/Firebase/m2repository/com/google/firebase/firebase-auth-unity/12.10.1/firebase-auth-unity-12.10.1.pom</file>
+    <file>Assets/GeneratedLocalRepo/Firebase/m2repository/com/google/firebase/firebase-database-unity/12.10.1/firebase-database-unity-12.10.1.aar</file>
+    <file>Assets/GeneratedLocalRepo/Firebase/m2repository/com/google/firebase/firebase-database-unity/12.10.1/firebase-database-unity-12.10.1.pom</file>
+  </files>
+  <settings>
+    <setting name="androidAbis" value="armeabi-v7a" />
+    <setting name="bundleId" value="com.NineTeam.ChickenRun" />
+    <setting name="explodeAars" value="True" />
+    <setting name="gradleBuildEnabled" value="True" />
+    <setting name="gradlePropertiesTemplateEnabled" value="True" />
+    <setting name="gradleTemplateEnabled" value="True" />
+    <setting name="installAndroidPackages" value="True" />
+    <setting name="localMavenRepoDir" value="Assets/GeneratedLocalRepo" />
+    <setting name="packageDir" value="Assets/Plugins/Android" />
+    <setting name="patchAndroidManifest" value="True" />
+    <setting name="patchMainTemplateGradle" value="True" />
+    <setting name="projectExportEnabled" value="False" />
+    <setting name="useFullCustomMavenRepoPathWhenExport" value="True" />
+    <setting name="useFullCustomMavenRepoPathWhenNotExport" value="False" />
+    <setting name="useJetifier" value="True" />
+  </settings>
+</dependencies>

--- a/ProjectSettings/GvhProjectSettings.xml
+++ b/ProjectSettings/GvhProjectSettings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<projectSettings>
+  <projectSetting name="GooglePlayServices.PromptBeforeAutoResolution" value="False" />
+  <projectSetting name="GooglePlayServices.UseJetifier" value="True" />
+</projectSettings>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -12,7 +12,7 @@ PlayerSettings:
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60
-  companyName: DefaultCompany
+  companyName: NineTeam
   productName: ChickenRun
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -11,9 +11,9 @@ TagManager:
   - 
   - Water
   - UI
-  - 
-  - 
-  - 
+  - Player
+  - Ground
+  - Egg
   - 
   - 
   - 


### PR DESCRIPTION

## 요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)

- 터치를 통한 플레이어 점프 (짧게 터치 : 낮은 점프, 길게 터치 : 높은 점프)
- 공중에서 2단점프 금지 및 터치 불가
- 트리거 충돌(달걀, 물, 결승점)
- 플레이 시간과 달걀 획득 관리 게임매니저 싱글톤 구현

## 작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
- 작업 1 : GetMouseButtonDown으로 터치 인풋
- 작업 2 : Add Force와 Lerp를 활용하여 부드러운 점프 구현
- 작업 2-1 : 점프의 방향을 Vector.Up + Vector.Right로 구현 시 높이 뛰면 앞으로 쭉 이동을 하여 Vector2(x, y)로 x 위치를 조절하여 앞으로 쭉 이동 개선
- 작업 3 : 터치 시간에 따라 점프의 파워 변화와 Clamp를 활용하여 min, max 설정
- 작업 4 : 바닥에 착지 시 물리적 충돌 확인으로 점프 상태를 확인하여 2단 점프 금지
- 작업 5 : 트리거 충돌(달걀, 물, 결승점) 달걀은 이벤트로 획득 시 UI변경, 물에 닿으면 스타트 위치이동, 게임 시작과 동시에 플레이 타임 측정하고 결승점에 도달하면 타임 측정 정지
- 작업 6 : 게임매니저를 싱글톤으로 구현하여 플레이타임, 달걀 획득 수, 스타트 위치 관리

## 해야 할 일 / 수정 사항
(아직 남아 있는 문제, 추가로 개선할 부분이나 향후 수정이 필요한 내용을 적어주세요)
- 네트워크로 동기화 하여 결승점에 도착하는 부분 확인 예정

## 체크리스트

- [ ] 코드가 정상적으로 빌드/실행된다
- [ ] 기능이 정상 동작한다
- [ ] 심각한 버그나 예상치 못한 문제는 없다