### PR TITLE
[Fix] Map1 Use Item Bug

### DIFF
--- a/Assets/04.Scenes/LoginScene.unity
+++ b/Assets/04.Scenes/LoginScene.unity
@@ -17881,6 +17881,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: SoundManager
       objectReference: {fileID: 0}
+    - target: {fileID: 2825829469202006260, guid: 959700c1f5b2c90438d26364077d17a3, type: 3}
+      propertyPath: _sfxFiles.Array.data[18]
+      value: 
+      objectReference: {fileID: 8300000, guid: 836dd139a405f9d458687d35a531c07f, type: 3}
     - target: {fileID: 7454621831225474847, guid: 959700c1f5b2c90438d26364077d17a3, type: 3}
       propertyPath: m_LocalPosition.x
       value: 2.0481257

--- a/Assets/05.KGW_Folder/Prefabs/Map1/Map1.prefab
+++ b/Assets/05.KGW_Folder/Prefabs/Map1/Map1.prefab
@@ -30,8 +30,8 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6208597491034480096}
-  - {fileID: 2938623630136417917}
-  - {fileID: 5899237548528409346}
+  - {fileID: 7324098470368172862}
+  - {fileID: 6453060983086108787}
   m_Father: {fileID: 4899852680204529338}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &26135257989082334
@@ -1940,126 +1940,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1558953502068038539
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5899237548528409346}
-  - component: {fileID: 8940263597149093845}
-  - component: {fileID: 7024145124288706400}
-  m_Layer: 14
-  m_Name: BoostItem (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5899237548528409346
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1558953502068038539}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 80.21, y: -5.94, z: 0.10223692}
-  m_LocalScale: {x: 0.15, y: 0.15, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5923147541845241278}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &8940263597149093845
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1558953502068038539}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 3
-  m_Sprite: {fileID: 21300000, guid: 830e8791937050d4588a8b162ba5ae93, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!58 &7024145124288706400
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1558953502068038539}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.5
 --- !u!1 &1599923732299845573
 GameObject:
   m_ObjectHideFlags: 0
@@ -40651,126 +40531,6 @@ CircleCollider2D:
   m_Offset: {x: 0, y: -0.017160833}
   serializedVersion: 2
   m_Radius: 0.5632525
---- !u!1 &4162972391686669772
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2938623630136417917}
-  - component: {fileID: 6143446463572182787}
-  - component: {fileID: 3876788706017363067}
-  m_Layer: 14
-  m_Name: BoostItem (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2938623630136417917
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4162972391686669772}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 21.07, y: 0.89, z: 0.10223692}
-  m_LocalScale: {x: 0.15, y: 0.15, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5923147541845241278}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &6143446463572182787
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4162972391686669772}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 3
-  m_Sprite: {fileID: 21300000, guid: 830e8791937050d4588a8b162ba5ae93, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!58 &3876788706017363067
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4162972391686669772}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.5
 --- !u!1 &4168605806702050884
 GameObject:
   m_ObjectHideFlags: 0
@@ -40891,6 +40651,126 @@ CircleCollider2D:
   m_Offset: {x: 0, y: -0.017160833}
   serializedVersion: 2
   m_Radius: 0.5632525
+--- !u!1 &4182591998315159548
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6453060983086108787}
+  - component: {fileID: 6647352621645008694}
+  - component: {fileID: 5464233718746238684}
+  m_Layer: 14
+  m_Name: BoostItem (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6453060983086108787
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4182591998315159548}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 68.55, y: -2.19, z: 0.10223692}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5923147541845241278}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6647352621645008694
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4182591998315159548}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 3
+  m_Sprite: {fileID: 21300000, guid: 830e8791937050d4588a8b162ba5ae93, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!70 &5464233718746238684
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4182591998315159548}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.013008118, y: -0.013008912}
+  m_Size: {x: 2.8405, y: 4.791855}
+  m_Direction: 0
 --- !u!1 &4225692327091849772
 GameObject:
   m_ObjectHideFlags: 0
@@ -41419,6 +41299,126 @@ CircleCollider2D:
   m_Offset: {x: 0, y: -0.017160833}
   serializedVersion: 2
   m_Radius: 0.5632525
+--- !u!1 &4409591329276830587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7324098470368172862}
+  - component: {fileID: 2866097090384013414}
+  - component: {fileID: 1340388512796094982}
+  m_Layer: 14
+  m_Name: BoostItem (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7324098470368172862
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4409591329276830587}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 36.3, y: 7.25, z: 0.10223692}
+  m_LocalScale: {x: 0.15, y: 0.15, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5923147541845241278}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2866097090384013414
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4409591329276830587}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 3
+  m_Sprite: {fileID: 21300000, guid: 830e8791937050d4588a8b162ba5ae93, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!70 &1340388512796094982
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4409591329276830587}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0.013008118, y: -0.013008912}
+  m_Size: {x: 2.8405, y: 4.791855}
+  m_Direction: 0
 --- !u!1 &4486108837092861819
 GameObject:
   m_ObjectHideFlags: 0
@@ -43575,7 +43575,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6208597491034480096}
   - component: {fileID: 108587808132723024}
-  - component: {fileID: 6841472433418640909}
+  - component: {fileID: 437467358252949117}
   m_Layer: 14
   m_Name: BoostItem
   m_TagString: Untagged
@@ -43650,8 +43650,8 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!58 &6841472433418640909
-CircleCollider2D:
+--- !u!70 &437467358252949117
+CapsuleCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -43682,9 +43682,9 @@ CircleCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.5
+  m_Offset: {x: 0.013008118, y: -0.013008912}
+  m_Size: {x: 2.8405, y: 4.791855}
+  m_Direction: 0
 --- !u!1 &5626247762302909518
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/05.KGW_Folder/Scripts/Item/BoostController.cs
+++ b/Assets/05.KGW_Folder/Scripts/Item/BoostController.cs
@@ -9,13 +9,13 @@ public class BoostController : MonoBehaviourPunCallbacks, IPunObservable
     [SerializeField] float _boostPower = 3f;
     [SerializeField] float _boostTime = 15f;
     [SerializeField] PlayerController_Map1 _playerController;
-    [SerializeField] Animator _dashAni;
+    [SerializeField] public Animator _dashAni;
 
     public bool _hasBoostItem = false;
-    bool _isBoost = false;
-    int _currentAnimatorHash;
+    public bool _isBoost = false;
+    public int _currentAnimatorHash;
     int _reciveAnimatorHash;
-    Coroutine _boostCoroutine;
+    public Coroutine _boostCoroutine;
 
     public readonly int DashIdle_Hash = Animator.StringToHash("DashIdle");
     public readonly int DashCharge_Hash = Animator.StringToHash("DashCharge");
@@ -85,15 +85,15 @@ public class BoostController : MonoBehaviourPunCallbacks, IPunObservable
 
         yield return new WaitForSeconds(1.5f);
 
+        // 대쉬 런 애니메이션
+        _currentAnimatorHash = DashRun_Hash;
+        _dashAni.Play(DashRun_Hash);
+
+        // 대쉬 사운드 재생
+        SoundManager.Instance.PlaySFX(SoundManager.Sfxs.SFX_Dash);
+
         while (timer < _boostTime)
         {
-            // 대쉬 런 애니메이션
-            _currentAnimatorHash = DashRun_Hash;
-            _dashAni.Play(DashRun_Hash);
-
-            // 대쉬 사운드 재생
-            SoundManager.Instance.PlaySFX(SoundManager.Sfxs.SFX_Dash);
-
             // 앞으로 전진하고 점프 가능
             _playerController._playerRigid.velocity = new Vector2(direction.x * _boostPower, _playerController._playerRigid.velocity.y);
 

--- a/Assets/05.KGW_Folder/Scripts/Player/Map1/PlayerController_Map1.cs
+++ b/Assets/05.KGW_Folder/Scripts/Player/Map1/PlayerController_Map1.cs
@@ -1,7 +1,9 @@
+using JetBrains.Annotations;
 using Photon.Pun;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -25,6 +27,7 @@ public class PlayerController_Map1 : MonoBehaviourPun, IPunObservable, IPunInsta
     Vector2 _jumpDir;
     Vector3 _currentPosition;
     Quaternion _currentRotation;
+    GameObject _ItemObj;
     float _touchStartTime;
     float _touchEndtTime;
     float _touchDuration;
@@ -253,7 +256,11 @@ public class PlayerController_Map1 : MonoBehaviourPun, IPunObservable, IPunInsta
                 SoundManager.Instance.PlaySFX(SoundManager.Sfxs.SFX_Item);
 
                 _boostController.GetBoostItem();
-                //Destroy(collision.gameObject);
+                _ItemObj = collision.gameObject;
+                collision.gameObject.SetActive(false);
+
+                Invoke(nameof(ItemRespawn), 3f);
+
             }
         }
 
@@ -263,6 +270,22 @@ public class PlayerController_Map1 : MonoBehaviourPun, IPunObservable, IPunInsta
             Debug.Log("물에 접촉");
             // 게임의 처음 위치로 이동
             _playerRigid.velocity = Vector2.zero;
+
+            if (_boostController._isBoost)
+            {
+                _boostController._isBoost = false;
+
+                if (_boostController._boostCoroutine != null)
+                {
+                    StopCoroutine(_boostController._boostCoroutine);
+                    _boostController._boostCoroutine = null;
+                }
+
+                // 대쉬 중 입수하면 대쉬 초기화
+                _boostController._currentAnimatorHash = _boostController.DashIdle_Hash;
+                _boostController._dashAni.Play(_boostController.DashIdle_Hash);
+            }
+
             gameObject.transform.position = _gameManager._startPos;
         }
 
@@ -296,6 +319,12 @@ public class PlayerController_Map1 : MonoBehaviourPun, IPunObservable, IPunInsta
             }
         }
 
+    }
+
+    // 아이템 재생성
+    private void ItemRespawn()
+    {
+        _ItemObj.SetActive(true);
     }
 
     // 도착한 플레이어

--- a/Assets/Resources/Player_Map1.prefab
+++ b/Assets/Resources/Player_Map1.prefab
@@ -550,6 +550,8 @@ MonoBehaviour:
   _playerController: {fileID: 8135776633713154748}
   _dashAni: {fileID: 881363893218262655}
   _hasBoostItem: 0
+  _isBoost: 0
+  _currentAnimatorHash: 0
 --- !u!1 &3902965431706400322
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION

## 요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)

-맵1에서 아이템을 사용 후 바다에 입수하면 부스터 상태로 스폰 확인하여 수정, 아이템 오브젝트 획득 후 재생성 방식으로 변경

## 작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
- 바다에 입수하면 부스터 코루틴 정지
- 부스트 조건 초기화
- 아이템 오브젝트 재생성
