### PR TITLE
[Fix] Map4 Exit Game SFX Sound Play Bug

### DIFF
--- a/Assets/05.KGW_Folder/Scripts/InGameUI/Map4/UIManager_Map4.cs
+++ b/Assets/05.KGW_Folder/Scripts/InGameUI/Map4/UIManager_Map4.cs
@@ -226,6 +226,13 @@ public class UIManager_Map4 : MonoBehaviourPun
     // 나가기 버튼 클릭
     private void OnExitPlayGame()
     {
+        // 효과음이 재생중이면
+        if(SoundManager.Instance._sfxAudioSource.isPlaying)
+        {
+            // 효과음 정지
+            SoundManager.Instance.StopSFX();
+        }
+
         string exitPlayer = _playerEmoticonController._nickname;
 
         _isExit = true;


### PR DESCRIPTION

## 요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)

-맵4에서 게임을 탈주를 해도 드릴의 효과음이 들리는 버그 확인하여 효과음 정지 추가했습니다.

## 작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
- 게임을 나가면 효과음이 재생중인지 체크를 하여 재생중이면 정지하게 수정
