### PR TITLE
[Fix] Map4 Player Die All Time Stop

### DIFF
--- a/Assets/04.Scenes/InGameScene/GameScene_Map1.unity
+++ b/Assets/04.Scenes/InGameScene/GameScene_Map1.unity
@@ -1271,6 +1271,14 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6650379805447070699, guid: 3417d7b8f169d224788f20616e925727, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 277.77
+      objectReference: {fileID: 0}
+    - target: {fileID: 6650379805447070699, guid: 3417d7b8f169d224788f20616e925727, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.19
+      objectReference: {fileID: 0}
     - target: {fileID: 9012042355409679943, guid: 3417d7b8f169d224788f20616e925727, type: 3}
       propertyPath: m_Name
       value: Map1

--- a/Assets/04.Scenes/InGameScene/GameScene_Map4.unity
+++ b/Assets/04.Scenes/InGameScene/GameScene_Map4.unity
@@ -8904,11 +8904,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7853422461085972769, guid: d1269e3deea3c3f4ab51a852e5ddc1b1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4.8
+      value: 4.02
       objectReference: {fileID: 0}
     - target: {fileID: 7853422461085972769, guid: d1269e3deea3c3f4ab51a852e5ddc1b1, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 131.42
+      value: 131.481
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Assets/05.KGW_Folder/Scripts/Player/Map4/PlayerController_Map4.cs
+++ b/Assets/05.KGW_Folder/Scripts/Player/Map4/PlayerController_Map4.cs
@@ -261,8 +261,12 @@ public class PlayerController_Map4 : MonoBehaviourPun, IPunObservable, IPunInsta
             SoundManager.Instance.PlaySFX(SoundManager.Sfxs.SFX_Death);
             string playerNickname = _playerEmoticonController._nickname;
 
+            if (photonView.IsMine)
+            {
+                _gameManager.StopStopWatch();
+            }
+
             gameObject.SetActive(false);
-            _gameManager.StopStopWatch();
             _gameManager.PlayerDeath(playerNickname);
         }
     }


### PR DESCRIPTION

## 요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)

-플레이어 한명이 사망하면 전인원 타이머 멈추는 버그 확인하여 수정

## 작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
- 사망시 스탑워치 스톱 메서드가 전인원에게 공유가 되는 문제로 자신만 스톱하도록 수정
